### PR TITLE
Update index.html link to intellisharp-home.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <h1><a id="contributing" class="anchor" href="#contributing" aria-hidden="true"><span class="octicon octicon-link"></span>Contributing</a></h1>
       <p>
         Contributions are welcome!
-        See the main <a href="https://github.com/intellisharp/intellisharp-home">Intelli# Home</a> repository on GitHub for more information.
+        See the main <a href="https://github.com/intellisharp/home">Intelli# Home</a> repository on GitHub for more information.
       </p>
       <p>
         This website is itself open-sourced and available at <a href="https://github.com/intellisharp/intellisharp.github.io">github.com/intellisharp/intellisharp.github.io</a>.


### PR DESCRIPTION
The `intellisharp-home` repository on GitHub is now just called `home`.